### PR TITLE
Adding a -v flag to the PostgreSQL Docker example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ To start a PostgreSQL container with PostGIS support:
 ```
 docker run -d \
     --name bagdb-postgres \
+    -v /var/lib/bagdb-postgres:/var/lib/postgresql/data \
     -e POSTGRES_PASSWORD=letmein \
     -e POSTGRES_USER=bag_database \
     -e POSTGRES_DB=bag_database \


### PR DESCRIPTION
The previous example wouldn't create a persistent database, which probably would've really annoyed people who were just copy/pasting the examples after the next time they recreated their Postgres container.