### PR TITLE
LZ4 compression support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Bag Database changelog
 
+2.3-SNAPSHOT
+
+- Adding support for LZ4 compression
+- Using Spring Session for user session tracking; sessions no longer time out
+
 2.2
 
 - Adding OpenCV to handle Bayer image formats

--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
         <dependency>
             <groupId>com.github.swri-robotics</groupId>
             <artifactId>bag-reader-java</artifactId>
-            <version>1.3</version>
+            <version>1.4</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/github/swrirobotics/bags/persistence/SpringSessionAttribute.java
+++ b/src/main/java/com/github/swrirobotics/bags/persistence/SpringSessionAttribute.java
@@ -58,7 +58,7 @@ public class SpringSessionAttribute implements Serializable {
     // long enough to store Spring's Security Context info.
     @Basic
     @Column(length = 10000)
-    public byte[] attribute_bytes; // TODO Make this work in hsql
+    public byte[] attribute_bytes;
 
     @Override
     public boolean equals(Object o) {


### PR DESCRIPTION
Updating to the latest bag reader library to add support for LZ4-compressed bag files.

Also removing a TODO that I forgot to remove in the previous commit.