### PR TITLE
Preserving widget states between reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 2.4-SNAPSHOT
 
+- Saving widget states between reloads
 - Adding more database indexes to improve search performance
 - Implementing a hierarchical folder view for the bag list
 - Adding some more button icons

--- a/src/main/webapp/resources/js/application.js
+++ b/src/main/webapp/resources/js/application.js
@@ -37,13 +37,18 @@ Ext.application({
                 'BagDatabase.views.SearchPanel',
                 'BagDatabase.views.BagTreeFilterPanel' ],
     launch: function() {
+        Ext.state.Manager.setProvider(new Ext.state.LocalStorageProvider());
         Ext.create('Ext.container.Viewport', {
             layout: 'fit',
             id: 'viewport',
             items: [{
                 xtype: 'tabpanel',
                 region: 'center',
-                activeTab: 0,
+                id: 'tabPanel',
+                stateful: true,
+                stateId: 'tabPanel',
+                stateEvents: ['tabchange'],
+                activeTab: Ext.state.Manager.get('active_tab', 0),
                 items: [{
                     xtype: 'panel',
                     layout: 'border',
@@ -51,10 +56,14 @@ Ext.application({
                     iconCls: 'table-icon',
                     items: [{
                         xtype: 'searchPanel',
+                        stateful: true,
+                        stateId: 'gridSearchPanel',
                         region: 'north'
                     }, {
                         xtype: 'bagGrid',
                         itemId: 'bagGrid',
+                        stateful: true,
+                        stateId: 'bagGrid',
                         title: 'Search Results',
                         region: 'center'
 
@@ -66,10 +75,14 @@ Ext.application({
                     iconCls: 'folder-icon',
                     items: [{
                         xtype: 'bagTreeFilterPanel',
+                        stateful: true,
+                        stateId: 'bagTreeFilterPanel',
                         region: 'north'
                     }, {
                         xtype: 'bagTreePanel',
                         itemId: 'bagTreePanel',
+                        stateful: true,
+                        stateId: 'bagTreePanel',
                         region: 'center'
                     }]
                 }],
@@ -117,6 +130,9 @@ Ext.application({
                 listeners: {
                     afterrender: function(bagGrid) {
                         bagGrid.down('#statusText').connectWebSocket(bagGrid.down('#errorButton'));
+                    },
+                    tabchange: function() {
+                        Ext.state.Manager.set('active_tab', Ext.getCmp('tabPanel').getActiveTab().getId());
                     }
                 }
             }]

--- a/src/main/webapp/resources/js/views/BagTreeFilterPanel.js
+++ b/src/main/webapp/resources/js/views/BagTreeFilterPanel.js
@@ -41,6 +41,8 @@ Ext.define('BagDatabase.views.BagTreeFilterPanel', {
             xtype: 'textfield',
             fieldLabel: 'Filter by File Name',
             itemId: 'filterText',
+            stateful: true,
+            stateId: 'filterText',
             name: 'filterText',
             flex: 1,
             margin: 5,

--- a/src/main/webapp/resources/js/views/SearchPanel.js
+++ b/src/main/webapp/resources/js/views/SearchPanel.js
@@ -42,6 +42,8 @@ Ext.define('BagDatabase.views.SearchPanel', {
             fieldLabel: 'Full Text Search',
             itemId: 'searchTerms',
             name: 'searchTerms',
+            stateful: true,
+            stateId: 'searchTerms',
             flex: 1,
             margin: 5,
             enableKeyEvents: true,
@@ -79,8 +81,19 @@ Ext.define('BagDatabase.views.SearchPanel', {
     }, {
         xtype: 'checkboxgroup',
         itemId: 'searchFields',
+        stateful: true,
+        stateId: 'gridSearchFields',
         anchor: '100%',
         columns: 7,
+        // The checkboxgroup widget doesn't actually save the states of its
+        // checkboxes by default, so we have to manually do that.
+        stateEvents: ['change'],
+        applyState: function(state) {
+            this.setValue(state);
+        },
+        getState: function() {
+            return this.getValue();
+        },
         getErrors: function(value) {
             var errors = [];
             var tnCheckbox = this.down('#topicNameCheckbox');


### PR DESCRIPTION
This uses HTML5 local storage to save the following:
- Selected tab
- Text in search boxes
- Checked search boxes
- Column visibility, order, and sorting

Resolves #38