### PR TITLE
Add ability to remove bags from DB when deleted from filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Bag Database changelog
 
+2.5-SNAPSHOT
+
+- Add an option to control whether entries should be removed from the DB if they are deleted from the filesystem
+- Missing bags will be deleted by default
+- Updated Spring & Hibernate-related dependencies to newer versions
+
 2.4
 
 - Fixing the mass vehicle name updater for the admin tool

--- a/pom.xml
+++ b/pom.xml
@@ -13,16 +13,16 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java-version>1.8</java-version>
         <!-- Override Spring version -->
-        <spring.version>4.3.0.RELEASE</spring.version>
+        <spring.version>4.3.3.RELEASE</spring.version>
         <!-- AssertJ is not a part of Spring IO platform, so the version must be provided explicitly -->
         <assertj-core-version>2.3.0</assertj-core-version>
-        <hibernate.version>5.1.0.Final</hibernate.version>
+        <hibernate.version>5.2.3.Final</hibernate.version>
         <aspectj.version>1.8.9</aspectj.version>
     </properties>
     <parent>
         <groupId>io.spring.platform</groupId>
         <artifactId>platform-bom</artifactId>
-        <version>2.0.5.RELEASE</version>
+        <version>2.0.8.RELEASE</version>
         <relativePath />
     </parent>
     <dependencies>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>2.4.5</version>
+            <version>2.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/src/main/java/com/github/swrirobotics/bags/filesystem/BagScanner.java
+++ b/src/main/java/com/github/swrirobotics/bags/filesystem/BagScanner.java
@@ -426,6 +426,10 @@ public class BagScanner extends StatusProvider implements RecursiveWatcher.Watch
                 bagService.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
 
                 myBagService.markMissingBags(missingBagMd5sums.values());
+
+                if (myConfigService.getConfiguration().getRemoveOnDeletion()) {
+                    myBagService.removeMissingBags();
+                }
             }
             catch (RuntimeException e) {
                 String error = "Unexpected exception when checking bag files: ";

--- a/src/main/java/com/github/swrirobotics/bags/persistence/Bag.java
+++ b/src/main/java/com/github/swrirobotics/bags/persistence/Bag.java
@@ -196,7 +196,8 @@ public class Bag implements Serializable {
         this.compressed = compressed;
     }
 
-    @ManyToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @ManyToMany(fetch = FetchType.EAGER,
+                cascade={CascadeType.REFRESH, CascadeType.PERSIST, CascadeType.MERGE})
     @JoinTable(name="bag_message_types",
             joinColumns = {@JoinColumn(name="bag_id", referencedColumnName="id")},
             inverseJoinColumns = {@JoinColumn(name="message_type_name", referencedColumnName = "name"),
@@ -209,7 +210,9 @@ public class Bag implements Serializable {
         this.messageTypes = messageTypes;
     }
 
-    @OneToMany(mappedBy = "bag", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @OneToMany(mappedBy = "bag",
+               cascade={CascadeType.REFRESH, CascadeType.PERSIST, CascadeType.MERGE},
+               fetch = FetchType.EAGER)
     public Set<Topic> getTopics() {
         return topics;
     }
@@ -236,7 +239,8 @@ public class Bag implements Serializable {
         this.missing = missing;
     }
 
-    @OneToMany(mappedBy = "bag", orphanRemoval = true)
+    @OneToMany(mappedBy = "bag",
+               cascade={CascadeType.REFRESH, CascadeType.PERSIST, CascadeType.MERGE})
     @JsonIgnore
     public List<BagPosition> getBagPositions() {
         return bagPositions;
@@ -320,7 +324,9 @@ public class Bag implements Serializable {
         this.longitudeDeg = longitudeDeg;
     }
 
-    @OneToMany(mappedBy = "bag", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "bag",
+               cascade={CascadeType.REFRESH, CascadeType.PERSIST, CascadeType.MERGE},
+               fetch = FetchType.EAGER)
     public Set<Tag> getTags() {
         return tags;
     }

--- a/src/main/java/com/github/swrirobotics/bags/persistence/BagPosition.java
+++ b/src/main/java/com/github/swrirobotics/bags/persistence/BagPosition.java
@@ -44,7 +44,7 @@ public class BagPosition {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch=FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch=FetchType.LAZY)
     @JoinColumn(name="bagId")
     @JsonIgnore
     private Bag bag;

--- a/src/main/java/com/github/swrirobotics/bags/persistence/MessageType.java
+++ b/src/main/java/com/github/swrirobotics/bags/persistence/MessageType.java
@@ -52,7 +52,7 @@ public class MessageType implements Serializable {
     @Id
     @Column(nullable = false, length = 32)
     private String md5sum;
-    @ManyToMany(mappedBy = "messageTypes", cascade = CascadeType.REMOVE)
+    @ManyToMany(mappedBy = "messageTypes")
     @JsonIgnore
     private Set<Bag> bags = new HashSet<>();
     @OneToMany(mappedBy = "type")

--- a/src/main/java/com/github/swrirobotics/bags/persistence/Tag.java
+++ b/src/main/java/com/github/swrirobotics/bags/persistence/Tag.java
@@ -50,7 +50,7 @@ public class Tag implements Serializable {
 
     @MapsId("bagId")
     @JoinColumn(name = "bagId")
-    @ManyToOne(optional=false, cascade = CascadeType.REMOVE)
+    @ManyToOne(optional=false)
     private Bag bag;
 
     public Bag getBag() {

--- a/src/main/java/com/github/swrirobotics/bags/persistence/Topic.java
+++ b/src/main/java/com/github/swrirobotics/bags/persistence/Topic.java
@@ -52,7 +52,7 @@ public class Topic implements Serializable {
 
     @MapsId("bagId")
     @JoinColumn(name = "bagId")
-    @ManyToOne(optional = false, cascade = CascadeType.REMOVE)
+    @ManyToOne(optional = false)
     private Bag bag;
 
     @Column(nullable = false)

--- a/src/main/java/com/github/swrirobotics/config/ConfigService.java
+++ b/src/main/java/com/github/swrirobotics/config/ConfigService.java
@@ -127,7 +127,7 @@ public class ConfigService {
         boolean bagPathChanged;
         try {
             // If the config is being set from the web interface, the user can
-            // leave the JDBC password blank to indicate that it sohuld not be
+            // leave the JDBC password blank to indicate that it should not be
             // changed.
             writer = new YamlWriter(new FileWriter(settingsFile.getFile()));
             if (config.getJdbcPassword() == null || config.getJdbcPassword().isEmpty()) {

--- a/src/main/java/com/github/swrirobotics/support/web/Configuration.java
+++ b/src/main/java/com/github/swrirobotics/support/web/Configuration.java
@@ -48,6 +48,7 @@ public class Configuration implements Serializable {
     private String[] vehicleNameTopics = new String[0];
     private String[] gpsTopics = new String[0];
     private Boolean debugJavascript = false;
+    private Boolean removeOnDeletion = true;
 
     public String getBagPath() {
         return bagPath;
@@ -151,5 +152,13 @@ public class Configuration implements Serializable {
 
     public void setDebugJavascript(Boolean debugJavascript) {
         this.debugJavascript = debugJavascript;
+    }
+
+    public Boolean getRemoveOnDeletion() {
+        return removeOnDeletion;
+    }
+
+    public void setRemoveOnDeletion(Boolean removeOnDeletion) {
+        this.removeOnDeletion = removeOnDeletion;
     }
 }

--- a/src/main/resources/db/changelog/db.changelog-1.4.yaml
+++ b/src/main/resources/db/changelog/db.changelog-1.4.yaml
@@ -1,0 +1,90 @@
+# Adds ON DELETE CASCADE constraints to tables that are linked to the Bags
+# table; having the database handle deleting related rows is faster than
+# doing it manually.
+databaseChangeLog:
+- changeSet:
+    id: cascade-deletes-1
+    author: preed
+    changes:
+    - dropForeignKeyConstraint:
+        baseTableName: bag_message_types
+        constraintName: fkbllasbl4tts9qqlp65smmx27j
+    - dropForeignKeyConstraint:
+        baseTableName: bag_message_types
+        constraintName: fk23bp9x92dlt909c2kh3tlnsme
+    - dropForeignKeyConstraint:
+        baseTableName: topics
+        constraintName: fkq10sryjifovphrbxq3hieccm2
+    - dropForeignKeyConstraint:
+        baseTableName: topics
+        constraintName: fkaiwajp9bca32j0n2pepdwqmg5
+    - dropForeignKeyConstraint:
+        baseTableName: tags
+        constraintName: fk8btgm03vue9r3f7p6wimgdf0g
+    - dropForeignKeyConstraint:
+        baseTableName: bag_positions
+        constraintName: fk25ij3r2ip8jkf31v35kq8gx1f
+- changeSet:
+    id: cascade-deletes-2
+    author: preed
+    changes:
+    - addForeignKeyConstraint:
+        baseColumnNames: bag_id
+        baseTableName: bag_message_types
+        constraintName: fk_bag_message_types_bags
+        deferrable: false
+        initiallyDeferred: false
+        onDelete: CASCADE
+        onUpdate: NO ACTION
+        referencedColumnNames: id
+        referencedTableName: bags
+    - addForeignKeyConstraint:
+        baseColumnNames: message_type_md5sum,message_type_name
+        baseTableName: bag_message_types
+        constraintName: fk_bag_message_types_message_types
+        deferrable: false
+        initiallyDeferred: false
+        onDelete: CASCADE
+        onUpdate: NO ACTION
+        referencedColumnNames: md5sum,name
+        referencedTableName: message_types
+    - addForeignKeyConstraint:
+        baseColumnNames: bagid
+        baseTableName: topics
+        constraintName: fk_topics_bags
+        deferrable: false
+        initiallyDeferred: false
+        onDelete: CASCADE
+        onUpdate: NO ACTION
+        referencedColumnNames: id
+        referencedTableName: bags
+    - addForeignKeyConstraint:
+        baseColumnNames: bagid
+        baseTableName: tags
+        constraintName: fk_tags_bags
+        deferrable: false
+        initiallyDeferred: false
+        onDelete: CASCADE
+        onUpdate: NO ACTION
+        referencedColumnNames: id
+        referencedTableName: bags
+    - addForeignKeyConstraint:
+        baseColumnNames: bagid
+        baseTableName: bag_positions
+        constraintName: fk_bag_positions_bags
+        deferrable: false
+        initiallyDeferred: false
+        onDelete: CASCADE
+        onUpdate: NO ACTION
+        referencedColumnNames: id
+        referencedTableName: bags
+    - addForeignKeyConstraint:
+        baseColumnNames: message_type_md5sum,message_type_name
+        baseTableName: topics
+        constraintName: fk_topics_message_types
+        deferrable: false
+        initiallyDeferred: false
+        onDelete: CASCADE
+        onUpdate: NO ACTION
+        referencedColumnNames: md5sum,name
+        referencedTableName: message_types

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -7,3 +7,5 @@ databaseChangeLog:
       file: db/changelog/db.changelog-1.2.yaml
   - include:
       file: db/changelog/db.changelog-1.3.yaml
+  - include:
+      file: db/changelog/db.changelog-1.4.yaml

--- a/src/main/webapp/resources/js/views/ConfigWindow.js
+++ b/src/main/webapp/resources/js/views/ConfigWindow.js
@@ -67,6 +67,12 @@ Ext.define('BagDatabase.views.ConfigWindow', {
             fieldLabel: 'Google API Key',
             name: 'googleApiKey'
         }, {
+            fieldLabel: 'Remove Bags from the Database on Deletion',
+            name: 'removeOnDeletion',
+            xtype: 'checkboxfield',
+            uncheckedValue: false,
+            inputvalue: true
+        }, {
             fieldLabel: 'Use MapQuest',
             name: 'useMapQuest',
             xtype: 'checkboxfield',


### PR DESCRIPTION
This adds a new config value, "removeOnDeletion", that will cause the bag DB
to remove entries from the database if the associated files disappeared from
the filesystem.  This will be set to true by default.

It also makes a few tweaks to the database schema so that foreign keys associated with the `bags` table all have "ON DELETE CASCADE" set on them, so that when bags are removed, the database will remove related rows; this is much faster than using Hibernate to delete them manually.

Resolves #49