### PR TITLE
Add faster codec option

### DIFF
--- a/src/main/docker/entrypoint.sh
+++ b/src/main/docker/entrypoint.sh
@@ -17,6 +17,7 @@ USE_TILE_MAP=${USE_TILE_MAP:-true}
 TILE_MAP_URL=${TILE_MAP_URL-"http://{a-d}.tile.stamen.com/terrain/{z}/{x}/{y}.jpg"}
 TILE_WIDTH_PX=${TILE_WIDTH_PX-256}
 TILE_HEIGHT_PX=${TILE_HEIGHT_PX-256}
+FASTER_CODEC=${FASTER_CODEC:-false}
 
 if [ ! -f ${HOME}/.ros-bag-database/settings.yml ]
 then
@@ -38,6 +39,7 @@ vehicleNameTopics: ${VEHICLE_NAME_TOPICS}
 metadataTopics: ${METADATA_TOPICS}
 gpsTopics: ${GPS_TOPICS}
 debugJavascript: ${DEBUG_JAVASCRIPT}
+fasterCodec: ${FASTER_CODEC}
 " > ${HOME}/.ros-bag-database/settings.yml
 fi
 

--- a/src/main/java/com/github/swrirobotics/bags/BagService.java
+++ b/src/main/java/com/github/swrirobotics/bags/BagService.java
@@ -544,28 +544,52 @@ public class BagService extends StatusProvider {
             // Generate key frames for seeking every 3 seconds
             String keyFrameRate = Double.toString(3*myFrameRate);
             // use (n-1) of n available processors, minimum 1
-            String numThreads = Integer.toString(Math.max(Runtime.getRuntime().availableProcessors()-1, 1));
+            String numThreads = Integer.toString(Math.min(16, Math.max(Runtime.getRuntime().availableProcessors()-1, 1)));
 
-            myFfmpegProc = Runtime.getRuntime().exec(
-                    new String[]{"ffmpeg",
-                                 "-f", "rawvideo",
-                                 "-c:v", "rawvideo",
-                                 "-pix_fmt", myPixelFormat,
-                                 "-s:v", myWidth + "x" + myHeight,
-                                 "-r:v", frameRateStr,
-                                 "-i", "pipe:0",
-                                 "-c:v", "libvpx",
-                                 "-f", "webm",
-                                 "-minrate", bitrate,
-                                 "-maxrate", bitrate,
-                                 "-b:v", bitrate,
-                                 "-threads", numThreads,
-                                 "-crf", "10",
-                                 "-t", durationStr,
-                                 "-g", keyFrameRate,
-                                 "pipe:1",
-                                 "-v", "warning"
-                    });
+            // Default encoding to create a VP8 stream
+            String[] command = new String[]{"ffmpeg",
+                    "-f", "rawvideo",
+                    "-c:v", "rawvideo",
+                    "-pix_fmt", myPixelFormat,
+                    "-s:v", myWidth + "x" + myHeight,
+                    "-r:v", frameRateStr,
+                    "-i", "pipe:0",
+                    "-c:v", "libvpx",
+                    "-f", "webm",
+                    "-minrate", bitrate,
+                    "-maxrate", bitrate,
+                    "-b:v", bitrate,
+                    "-threads", numThreads,
+                    "-crf", "10",
+                    "-t", durationStr,
+                    "-g", keyFrameRate,
+                    "pipe:1",
+                    "-v", "warning"
+            };
+
+            // Faster encoding
+            if (myConfigService.getConfiguration().getFasterCodec()) {
+            	command = new String[]{"ffmpeg",
+                        "-f", "rawvideo",
+                        "-c:v", "rawvideo",
+                        "-pix_fmt", myPixelFormat,
+                        "-s:v", myWidth + "x" + myHeight,
+                        "-r:v", frameRateStr,
+                        "-i", "pipe:0",
+                        "-c:v", "libvpx",
+                        "-f", "webm",
+                        "-vf", "scale=400:-1",
+                        "-threads", numThreads,
+                        "-crf", "28",
+                        "-r", "24",
+                        "-t", durationStr,
+                        "-g", keyFrameRate,
+                        "pipe:1",
+                        "-v", "warning"
+                };
+            }
+
+            myFfmpegProc = Runtime.getRuntime().exec(command);
 
             myConsumer = new OutputConsumer();
             myConsumer.start();

--- a/src/main/java/com/github/swrirobotics/support/web/Configuration.java
+++ b/src/main/java/com/github/swrirobotics/support/web/Configuration.java
@@ -49,6 +49,7 @@ public class Configuration implements Serializable {
     private String[] gpsTopics = new String[0];
     private Boolean debugJavascript = false;
     private Boolean removeOnDeletion = true;
+    private Boolean fasterCodec = false;
 
     // Named "useMapQuest" for legacy support with older configs;
     // MapQuest is actually unsupported now and this will enable/disable
@@ -200,5 +201,13 @@ public class Configuration implements Serializable {
 
     public void setMetadataTopics(String[] metadataTopics) {
         this.metadataTopics = metadataTopics;
+    }
+
+    public Boolean getFasterCodec() {
+    	return fasterCodec;
+    }
+
+    public void setFasterCodec(Boolean fasterCodec) {
+    	this.fasterCodec = fasterCodec;
     }
 }


### PR DESCRIPTION
This can be used on lower spec machines or to allow multiple users to
access video streams.

The main difference is: we scale down the output video stream to a width of 400 (we maintain the aspect ratio), we change the crf parameter to 28 reducing the quality, and finally we reduce the output framerate to 24. 

The main assumption is that the database is not used for high-resolution video viewing but rather quick scans of the content.

Also, we limit the number of threads to 16 (ffmpeg issues warnings when using more than 16 explaining that it is not recommended to go over this number).