### PR TITLE
Fix LZ4 decompression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Forthcoming
 
+- Fix issues decompressing LZ4-compressed chunks
 - Updated dependencies
 
 2.6.0

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
         <dependency>
             <groupId>com.github.swri-robotics</groupId>
             <artifactId>bag-reader-java</artifactId>
-            <version>1.7</version>
+            <version>1.8.0</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
An issue when decompressing LZ4-compressed data chunks could cause
it to not work properly, so it would not be possible to view
images or movies from LZ4-compressed bags.