### PR TITLE
Fix wrong column type being used on Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Forthcoming
 
+- Fix improper column types because created on newer Postgres DBs
 - Fix issues decompressing LZ4-compressed chunks
 - Updated dependencies
 

--- a/src/main/resources/db/changelog/db.changelog-1.8.yaml
+++ b/src/main/resources/db/changelog/db.changelog-1.8.yaml
@@ -1,0 +1,29 @@
+# At some point, columns defined with a type of "blob" began to be
+# created as "oid" columns rather than "bytea" columns in Postgres.
+# The spring_session_attributes table had a "blob" column that we
+# need to be "bytea", so drop the old column and create it with
+# the right type of necessary.
+# Note that there's no need to worry about migrating data, because if
+# it had been created as an "oid", we never would have successfully
+# inserted data into it in the first place.
+databaseChangeLog:
+- changeSet:
+    id: replace-oid-column-with-bytea-1
+    author: preed
+    preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: postgresql
+        - sqlCheck:
+            expectedResult: 1
+            sql: SELECT COUNT(column_name) FROM information_schema.columns WHERE table_name = 'spring_session_attributes' AND data_type = 'oid'
+    changes:
+    - dropColumn:
+        tableName: spring_session_attributes
+        columnName: attribute_bytes
+    - addColumn:
+        tableName: spring_session_attributes
+        columns:
+        - column:
+            name: attribute_bytes
+            type: bytea

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -15,3 +15,5 @@ databaseChangeLog:
       file: db/changelog/db.changelog-1.6.yaml
   - include:
       file: db/changelog/db.changelog-1.7.yaml
+  - include:
+      file: db/changelog/db.changelog-1.8.yaml


### PR DESCRIPTION
On newer versions of Postgres, the "attribute_bytes" column of the
"spring_session_attributes" table was being created with the type "oid",
but it should be "bytea".  This will detect if the column was created
with the wrong type and change it if necessary.