### PR TITLE
Fix setting bag metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Forthcoming
 
+- Fix manually setting metadata on bags without GPS coordinates
 - Fix improper column types because created on newer Postgres DBs
 - Fix issues decompressing LZ4-compressed chunks
 - Updated dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
         <dependency>
             <groupId>com.github.swri-robotics</groupId>
             <artifactId>bag-reader-java</artifactId>
-            <version>1.8.0</version>
+            <version>1.9.0</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/github/swrirobotics/bags/BagService.java
+++ b/src/main/java/com/github/swrirobotics/bags/BagService.java
@@ -887,7 +887,14 @@ public class BagService extends StatusProvider {
     public void updateBag(Bag newBag) {
         Bag dbBag = bagRepository.findOne(newBag.getId());
         dbBag.setDescription(newBag.getDescription());
-        dbBag.setCoordinate(makePoint(newBag.getLatitudeDeg(), newBag.getLongitudeDeg()));
+        if (newBag.getLatitudeDeg() != null && newBag.getLongitudeDeg() != null)
+        {
+            dbBag.setCoordinate(makePoint(newBag.getLatitudeDeg(), newBag.getLongitudeDeg()));
+        }
+        else
+        {
+            dbBag.setCoordinate(null);
+        }
         dbBag.setLocation(newBag.getLocation());
         dbBag.setVehicle(newBag.getVehicle());
         dbBag.getTags().addAll(newBag.getTags());


### PR DESCRIPTION
Manually setting metadata would fail for bag files that did not have
any GPS coordinates.

Fixes #81