### PR TITLE
fix for "Copy Link" bug  in Folder view (still present)

### DIFF
--- a/src/main/webapp/resources/js/views/BagTreePanel.js
+++ b/src/main/webapp/resources/js/views/BagTreePanel.js
@@ -329,7 +329,7 @@ Ext.define('BagDatabase.views.BagTreePanel', {
                         bags.forEach(function(record) {
                             links.push(document.location.href +
                                 'bags/download?bagId=' +
-                                 record.get('id'));
+                                 record.get('bagId'));
                         });
                         bagGrid.copyTextToClipboard(links.join('\n'));
                     }


### PR DESCRIPTION
Despite commit [29bef13f17](https://github.com/swri-robotics/bag-database/commit/29bef13f17a1417e10828408035ffd09bbdec047), the _Copy Link_ bug is still present in Folder View.  This pull request fixes it.