### PR TITLE
Add perl in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bag Database changelog
 
+2.7.2
+
+- Add perl to Dockerfile to fix parsing GPS, metadata, and vehicle name topics
+
 2.7.1
 
 - Fix issue with indexing bags with GPS topics that don't have latitude/longitude fields

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer="preed@swri.org"
 VOLUME ["/bags", "/root/.ros-bag-database/indexes", "/usr/local/tomcat/logs"]
 EXPOSE 8080
 
-RUN apk add --no-cache ffmpeg
+RUN apk add --no-cache ffmpeg perl
 RUN rm -rf /usr/local/tomcat/webapps/
 COPY --from=base-layer /src/target/*.war /usr/local/tomcat/webapps/ROOT.war
 COPY src/main/docker/entrypoint.sh /

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.swri-robotics</groupId>
     <artifactId>bag-database</artifactId>
     <packaging>war</packaging>
-    <version>2.7.1</version>
+    <version>2.7.2</version>
     <name>Bag Database</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -248,7 +248,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.10</version>
+            <version>1.18</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -294,7 +294,7 @@
         <dependency>
             <groupId>com.github.swri-robotics</groupId>
             <artifactId>bag-reader-java</artifactId>
-            <version>1.9.0</version>
+            <version>1.10.2</version>
         </dependency>
 
     </dependencies>

--- a/src/main/webapp/resources/js/views/AboutWindow.js
+++ b/src/main/webapp/resources/js/views/AboutWindow.js
@@ -35,9 +35,9 @@ Ext.define('BagDatabase.views.AboutWindow', {
     layout: 'fit',
     bodyPadding: 5,
     constrainHeader: true,
-    html: "<h2>Bag Database 2.7.1</h2>" +
+    html: "<h2>Bag Database 2.7.2</h2>" +
         "<p><a href='https://github.com/swri-robotics/bag-database'>https://github.com/swri-robotics/bag-database</a></p>" +
-        "<p>Copyright 2015-2017 Southwest Research Institute</p>" +
+        "<p>Copyright 2015-2019 Southwest Research Institute</p>" +
         "<br>" +
         "<p>Icons provided by <a href='http://www.famfamfam.com/lab/icons/silk/'>http://www.famfamfam.com/lab/icons/silk/</a></p>" +
         "<p>A number of open source libraries were used in the creation of this software;<br>" +


### PR DESCRIPTION
The Docker image being built did not have perl in it, which was causing
it to fail to parse lists of GPS coordinates, metadata, and vehicle name
topics from the environment when starting a new container

Fixes #82
Fixes #98