### PR TITLE
Fix path to image in Docker examples

### DIFF
--- a/docs/installation/docker/behind-a-reverse-proxy.md
+++ b/docs/installation/docker/behind-a-reverse-proxy.md
@@ -44,7 +44,7 @@ services:
             - docker_cache:/var/lib/docker
         command: ["dockerd", "--host=tcp://0.0.0.0:2375"]
     bagdb:
-        image: swri-robotics/bag-database:latest
+        image: swrirobotics/bag-database:latest
         networks:
             - bagdb
         depends_on:

--- a/docs/installation/docker/with-ldap-authentication.md
+++ b/docs/installation/docker/with-ldap-authentication.md
@@ -27,7 +27,7 @@ services:
             - docker_cache:/var/lib/docker
         command: ["dockerd", "--host=tcp://0.0.0.0:2375"]
     bagdb:
-        image: swri-robotics/bag-database:latest
+        image: swrirobotics/bag-database:latest
         networks:
             - bagdb
         depends_on:

--- a/docs/installation/docker/without-authentication.md
+++ b/docs/installation/docker/without-authentication.md
@@ -36,7 +36,7 @@ services:
         # SSL is disabled since only the Bag Database can access this anyway.
         # Be careful about allowing anything else to access this service!  
     bagdb:
-        image: swri-robotics/bag-database:latest
+        image: swrirobotics/bag-database:latest
         networks:
             - bagdb
         depends_on:

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -20,7 +20,7 @@ copy of the database container's volume.
 
 As long as you're using the same version of PostgreSQL, upgrading should be
 painless.  Pull the latest version of the Bag Database image
-(`docker pull swri-robotics/bag-database:latest`) and restarts its container;
+(`docker pull swrirobotics/bag-database:latest`) and restarts its container;
 if there are any database schema changes, it will automatically update everything.
 
 If you are also updating your PostgreSQL container, you will need to manually


### PR DESCRIPTION
The examples referred to an organization named "swri-robotics", but
actually "swrirobotics" is correct.

Fixes #119