### PR TITLE
Fix running scripts w/ multiple bags with the same name

### DIFF
--- a/src/main/java/com/github/swrirobotics/scripts/RunnableScript.java
+++ b/src/main/java/com/github/swrirobotics/scripts/RunnableScript.java
@@ -191,9 +191,10 @@ public class RunnableScript implements Runnable {
             List<String> command = new ArrayList<>();
             command.add(SCRIPT_TMP_NAME);
             for (Bag bag : bags) {
-                bindBuilder.add(Joiner.on(':').join(bag.getPath() + "/" + bag.getFilename(),
-                    "/" + bag.getFilename(), ""));
-                command.add("/" + bag.getFilename());
+                String absolutePath = bag.getPath() + "/" + bag.getFilename();
+                bindBuilder.add(Joiner.on(':').join(absolutePath,
+                    "/" + absolutePath, ""));
+                command.add("/" + absolutePath);
             }
 
             // Pull the Docker image to make sure it's ready


### PR DESCRIPTION
If multiple bags were in different paths but had the same filename, they
would all be mounted at the same point inside the Docker container used
to run scripts, making it so that only one of them could actually be processed.
This adds the full path to the bag to its mount point to ensure it is unique.

Fixed #130

Signed-off-by: P. J. Reed <preed@swri.org>