### PR TITLE
Increase max upload size to 50GB

### DIFF
--- a/src/main/java/com/github/swrirobotics/config/WebAppInitializer.java
+++ b/src/main/java/com/github/swrirobotics/config/WebAppInitializer.java
@@ -41,7 +41,7 @@ import javax.servlet.MultipartConfigElement;
 import javax.servlet.ServletRegistration;
 
 public class WebAppInitializer extends AbstractAnnotationConfigDispatcherServletInitializer {
-    public static Long maxUploadSizeBytes = 1024L * 1024L * 1024L * 4L; // 4 GB
+    public static Long maxUploadSizeBytes = 1024L * 1024L * 1024L * 50L; // 50 GB
 
     @Override
     protected String[] getServletMappings() {

--- a/src/main/webapp/resources/js/views/BagUploadWindow.js
+++ b/src/main/webapp/resources/js/views/BagUploadWindow.js
@@ -269,8 +269,8 @@ Ext.define('BagDatabase.views.BagUploadWindow', {
             fd.append('file', item.get('file'));
             xhr.setRequestHeader("serverTimeDiff", 0);
             xhr.onreadystatechange = function() {
-                if (xhr.readyState == 4) {
-                    if (xhr.status == 200) {
+                if (xhr.readyState === 4) {
+                    if (xhr.status === 200) {
                         //handle the answer, in order to detect any server side error
                         var response = Ext.decode(xhr.responseText);
                         if (response.success) {
@@ -280,8 +280,11 @@ Ext.define('BagDatabase.views.BagUploadWindow', {
                             item.set('status', 'Error: ' + response.message);
                         }
                     }
-                    else if (xhr.status == 500) {
+                    else if (xhr.status === 500) {
                         item.set('status', 'Error');
+                    }
+                    else if (xhr.status === 0) {
+                        item.set('status', 'Max upload size (50GB) exceeded');
                     }
                     else {
                         item.set('status', 'Unknown');


### PR DESCRIPTION
The maximum upload size was set to 4GB, which is smaller than many bag files, so this increases the maximum to 50GB.  It also displays a more useful error message in the upload box if the size is exceeded.

Fixes #134