### PR TITLE
Extend async task timeout

### DIFF
--- a/src/main/java/com/github/swrirobotics/bags/BagService.java
+++ b/src/main/java/com/github/swrirobotics/bags/BagService.java
@@ -344,6 +344,7 @@ public class BagService extends StatusProvider {
                 }
                 finally {
                     myLogger.debug("Finished processing output from ffmpeg.");
+                    IOUtils.closeQuietly(myOutput);
                 }
             }
         }


### PR DESCRIPTION
Spring was killing async tasks that ran longer than 30 seconds, which was preventing users from streaming long videos.  This extends the timeout to 1 hour.

Fixes #153.