### PR TITLE
Bag updater would stop working due to exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bag Database changelog
 
+3.4.1
+- Increase maximum bag file name length to 255 characters
+- Don't prevent adding bags if the bag removal task fails
+
 3.4.0
 - Add CORS and Range support to /bags/download
 - Add context menu item to open bags in external applications

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.swri-robotics</groupId>
     <artifactId>bag-database</artifactId>
     <packaging>war</packaging>
-    <version>3.4.0</version>
+    <version>3.4.1</version>
     <name>Bag Database</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/github/swrirobotics/bags/storage/filesystem/FilesystemBagStorageImpl.java
+++ b/src/main/java/com/github/swrirobotics/bags/storage/filesystem/FilesystemBagStorageImpl.java
@@ -185,10 +185,6 @@ public class FilesystemBagStorageImpl extends StatusProvider implements BagStora
             }
 
         });
-
-        if (configService.getConfiguration().getRemoveOnDeletion()) {
-            bagService.removeMissingBags();
-        }
     }
 
     @Override

--- a/src/main/java/com/github/swrirobotics/bags/storage/s3/S3BagStorageImpl.java
+++ b/src/main/java/com/github/swrirobotics/bags/storage/s3/S3BagStorageImpl.java
@@ -232,12 +232,6 @@ public class S3BagStorageImpl extends StatusProvider implements BagStorage {
                 myLogger.error("Unexpected error updating bag file:", e);
             }
         }
-
-        // At this point, if any bags were marked as missing because they were moved, they should have been updated.
-        // Remove any that are still missing from the database.
-        if (configService.getConfiguration().getRemoveOnDeletion()) {
-            bagService.removeMissingBags();
-        }
     }
 
     @Override

--- a/src/main/java/com/github/swrirobotics/persistence/Bag.java
+++ b/src/main/java/com/github/swrirobotics/persistence/Bag.java
@@ -112,12 +112,15 @@ public class Bag implements Serializable {
         this.id = id;
     }
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false)
     public String getFilename() {
         return filename;
     }
 
     public void setFilename(String filename) {
+        if (filename != null && filename.length() > 255) {
+            filename = filename.substring(0, 255);
+        }
         this.filename = filename;
     }
 

--- a/src/main/resources/db/changelog/db.changelog-2.3.yaml
+++ b/src/main/resources/db/changelog/db.changelog-2.3.yaml
@@ -1,0 +1,11 @@
+# With the support for multiple different storage backends, it is necessary
+# to track which bag file was created by which backend.
+databaseChangeLog:
+  - changeSet:
+      id: increase-bags-filename-length
+      author: preed
+      changes:
+        - modifyDataType:
+            tableName: 'bags'
+            columnName: filename
+            newDataType: VARCHAR(255)

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -23,3 +23,5 @@ databaseChangeLog:
       file: db/changelog/db.changelog-2.1.yaml
   - include:
       file: db/changelog/db.changelog-2.2.yaml
+  - include:
+      file: db/changelog/db.changelog-2.3.yaml

--- a/src/main/webapp/resources/js/views/AboutWindow.js
+++ b/src/main/webapp/resources/js/views/AboutWindow.js
@@ -35,7 +35,7 @@ Ext.define('BagDatabase.views.AboutWindow', {
     layout: 'fit',
     bodyPadding: 5,
     constrainHeader: true,
-    html: "<h2>Bag Database 3.4.0</h2>" +
+    html: "<h2>Bag Database 3.4.1</h2>" +
         "<p>Documentation: <a href='https://swri-robotics.github.io/bag-database/'>https://swri-robotics.github.io/bag-database/</a></p>" +
         "<p>Source Code: <a href='https://github.com/swri-robotics/bag-database'>https://github.com/swri-robotics/bag-database</a></p>" +
         "<p>Copyright 2015-2020 Southwest Research Institute</p>" +


### PR DESCRIPTION
When the bag updater was scanning for new bags, if it encountered an exception while scanning, that can cause the entire operation to abort and not update or add any bags.

That's not necessarily a bad thing -- we don't want the database to end up in a bad state if it encounters some broken data -- but there were two particular exceptions causing it to stop that should be handled better.

First, this MR increases the maximum length of bag names to 255 characters, which is the maximum length allowed by most Linux filesystems.  It will also truncate files with longer names down to 255 characters.  This will stop it from throwing an exception for bags with long names.

Second, after updating is done, it attempts to remove bag files that are missing on the filesystem from the database.  If this threw an exception, it would roll back adding any new bags even if there was nothing wrong with them.  This moves the removal process into its own transaction so that new bags will still be added even if there are issues removing missing ones.

Fixes #157