### PR TITLE
Update Documentation to Reference New Registry Location

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -18,7 +18,7 @@ to everybody who has contributed to it.
 
 The Bag Database's source code is hosted on GitHub at [https://github.com/swri-robotics/bag-database](https://github.com/swri-robotics/bag-database).
 
-Pre-built Docker images are on Docker Hub at [https://hub.docker.com/r/swrirobotics/bag-database](https://hub.docker.com/r/swrirobotics/bag-database).
+Pre-built Docker images are on Docker Hub at [https://ghcr.io/swri-robotics/bag-database/bag-database:latest](https://ghcr.io/swri-robotics/bag-database/bag-database:latest).
 
 Let us know how it works for you!
 

--- a/docs/installation/docker/behind-a-reverse-proxy.md
+++ b/docs/installation/docker/behind-a-reverse-proxy.md
@@ -49,7 +49,7 @@ services:
             - docker_cache:/var/lib/docker
         command: ["dockerd", "--host=tcp://0.0.0.0:2375"]
     bagdb:
-        image: swrirobotics/bag-database:latest
+        image: ghcr.io/swri-robotics/bag-database/bag-database:latest
         networks:
             - bagdb
         depends_on:

--- a/docs/installation/docker/with-a-private-registry.md
+++ b/docs/installation/docker/with-a-private-registry.md
@@ -45,7 +45,7 @@ services:
         volumes:
             - registry:/var/lib/registry 
     bagdb:
-        image: swrirobotics/bag-database:latest
+        image: ghcr.io/swri-robotics/bag-database/bag-database:latest
         networks:
             - bagdb
         depends_on:

--- a/docs/installation/docker/with-ldap-authentication.md
+++ b/docs/installation/docker/with-ldap-authentication.md
@@ -29,7 +29,7 @@ services:
             - docker_cache:/var/lib/docker
         command: ["dockerd", "--host=tcp://0.0.0.0:2375"]
     bagdb:
-        image: swrirobotics/bag-database:latest
+        image: ghcr.io/swri-robotics/bag-database/bag-database:latest
         networks:
             - bagdb
         depends_on:

--- a/docs/installation/docker/without-authentication.md
+++ b/docs/installation/docker/without-authentication.md
@@ -36,7 +36,7 @@ services:
         # SSL is disabled since only the Bag Database can access this anyway.
         # Be careful about allowing anything else to access this service!  
     bagdb:
-        image: swrirobotics/bag-database:latest
+        image: ghcr.io/swri-robotics/bag-database/bag-database:latest
         networks:
             - bagdb
         depends_on:

--- a/docs/installation/docker/without-compose.md
+++ b/docs/installation/docker/without-compose.md
@@ -26,7 +26,7 @@ docker run -d \
     -e METADATA_TOPICS="/metadata" \
     -e VEHICLE_NAME_TOPICS="/vehicle_name" \
     -e GPS_TOPICS="/localization/gps, /gps, /imu/fix" \
-    swrirobotics/bag-database:latest
+    ghcr.io/swri-robotics/bag-database/bag-database:latest
 ```
 
 After the bag database has successfully started, the bag database should be

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -20,7 +20,7 @@ copy of the database container's volume.
 
 As long as you're using the same version of PostgreSQL, upgrading should be
 painless.  Pull the latest version of the Bag Database image
-(`docker pull swrirobotics/bag-database:latest`) and restarts its container;
+(`docker pull ghcr.io/swri-robotics/bag-database/bag-database:latest`) and restarts its container;
 if there are any database schema changes, it will automatically update everything.
 
 If you are also updating your PostgreSQL container, you will need to manually


### PR DESCRIPTION
Changes references in documentation from old Docker Hub registry location to new ghcr.io location.