### PR TITLE
Update liquibase & fix ldap bean loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Forthcoming
 - Update dependencies to address the Spring4Shell vulnerability (https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement)
+- Update liquibase
+- Fix issue where LDAP beans were being initalized even with no LDAP configuration
 
 3.4.2
 - Fix admin functions for forcing bag scanning

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>3.8.9</version>
+            <version>4.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.mattbertolini</groupId>

--- a/src/main/java/com/github/swrirobotics/config/SecurityConfig.java
+++ b/src/main/java/com/github/swrirobotics/config/SecurityConfig.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
 import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.security.access.AccessDeniedException;
@@ -190,6 +191,7 @@ class SecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
     @Bean
+    @Lazy
     public LdapAuthenticationProvider ldapAuthenticationProvider() {
         return new LdapAuthenticationProvider(ldapAuthenticator(), ldapAuthoritiesPopulator());
     }
@@ -205,6 +207,7 @@ class SecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
     @Bean
+    @Lazy
     public LdapContextSource ldapContextSource() {
         com.github.swrirobotics.support.web.Configuration config = myConfigService.getConfiguration();
         String ldapProvider = "";
@@ -228,6 +231,7 @@ class SecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
     @Bean
+    @Lazy
     public LdapAuthenticator ldapAuthenticator() {
         BindAuthenticator authenticator = new BindAuthenticator(ldapContextSource());
         com.github.swrirobotics.support.web.Configuration config = myConfigService.getConfiguration();


### PR DESCRIPTION
Spring was trying to load LDAP-related beans even if no LDAP configuration
had been set, which would result in them throwing exceptions and shutting
everything down.

This marks the beans as @Lazy so they won't get initialized until the first
time they're used, which won't happen if there is no LDAP configuration.

I also went ahead and updated liquibase to 4.4.0 and tested it, and that
seems to work fine, so I'm including that, too.

Signed-off-by: P. J. Reed <phillipreed@hatchbed.com>