### PR TITLE
Handle invalid metadata in bag files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -414,9 +414,9 @@
 
         <!-- Reading and deserializing bag files -->
         <dependency>
-            <groupId>com.github.swri-robotics</groupId>
+            <groupId>io.github.hatchbed</groupId>
             <artifactId>bag-reader-java</artifactId>
-            <version>1.10.3</version>
+            <version>2.0.0</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/github/swrirobotics/bags/BagService.java
+++ b/src/main/java/com/github/swrirobotics/bags/BagService.java
@@ -1292,7 +1292,7 @@ public class BagService extends StatusProvider {
      * @param bagFile The bag file to read metadata for.
      * @return A map of all of the key:value metadata in the bag.
      */
-    private Map<String, String> getMetadata(BagFile bagFile) {
+    public Map<String, String> getMetadata(BagFile bagFile) {
         final Map<String, String> tags = Maps.newHashMap();
         String[] topics = myConfigService.getConfiguration().getMetadataTopics();
         try {
@@ -1306,8 +1306,9 @@ public class BagService extends StatusProvider {
                         myLogger.debug("Examining message: " + data);
                         tags.putAll(lineSplitter.split(data));
                     }
-                    catch (UninitializedFieldException e) {
-                        // continue
+                    catch (IllegalArgumentException | UninitializedFieldException e) {
+                        reportStatus(Status.State.ERROR,
+                            "Unable to parse metadata on topic " + topic + " in bag file " + bagFile.getPath());
                     }
                     return true;
                 });

--- a/src/test/java/com/github/swrirobotics/bags/BagControllerTest.java
+++ b/src/test/java/com/github/swrirobotics/bags/BagControllerTest.java
@@ -59,6 +59,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -84,7 +85,7 @@ public class BagControllerTest extends WebAppConfigurationAware {
 
             @Override
             public BagFile getBagFile() throws BagReaderException {
-                return new BagFile("/test.bag");
+                return mock(BagFile.class);
             }
 
             @Override


### PR DESCRIPTION
If the bag database was unable to parse the metadata in a bag file, it would throw an exception and cause it to completely fail to read the bag file.  This change will make it log an error but continue processing the file.  It also switches to a newer version of the `bag-reader-java` library that will allow for creating mock `BagFile` objects for the purpose of unit tests.

Signed-off-by: P. J. Reed <phillipreed@hatchbed.com>