### PR TITLE
Simplifying docker registry paths

### DIFF
--- a/docker/ldap_authentication/docker-compose.yml
+++ b/docker/ldap_authentication/docker-compose.yml
@@ -11,7 +11,7 @@ services:
             - docker_cache:/var/lib/docker
         command: ["dockerd", "--host=tcp://0.0.0.0:2375"]
     bagdb:
-        image: ghcr.io/swri-robotics/bag-database/bag-database:latest
+        image: ghcr.io/swri-robotics/bag-database:latest
         networks:
             - bagdb
         depends_on:

--- a/docker/private_registry/docker-compose.yml
+++ b/docker/private_registry/docker-compose.yml
@@ -20,7 +20,7 @@ services:
         volumes:
             - registry:/var/lib/registry 
     bagdb:
-        image: ghcr.io/swri-robotics/bag-database/bag-database:latest
+        image: ghcr.io/swri-robotics/bag-database:latest
         networks:
             - bagdb
         depends_on:

--- a/docker/reverse_proxy/docker-compose.yml
+++ b/docker/reverse_proxy/docker-compose.yml
@@ -21,7 +21,7 @@ services:
             - docker_cache:/var/lib/docker
         command: ["dockerd", "--host=tcp://0.0.0.0:2375"]
     bagdb:
-        image: ghcr.io/swri-robotics/bag-database/bag-database:latest
+        image: ghcr.io/swri-robotics/bag-database:latest
         networks:
             - bagdb
         depends_on:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,7 +19,7 @@
 # in the templates via {{ site.myvariable }}.
 
 title: Bag Database
-email: preed@swri.org
+email: swri-robotics@swri.org
 description: >- # this means to ignore newlines until "baseurl:"
   The Bag Database is a web-based application that makes it simple to catalogue
   ROS bag files, search through them, and perform operations on them.

--- a/docs/about.md
+++ b/docs/about.md
@@ -18,7 +18,7 @@ to everybody who has contributed to it.
 
 The Bag Database's source code is hosted on GitHub at [https://github.com/swri-robotics/bag-database](https://github.com/swri-robotics/bag-database).
 
-Pre-built Docker images are on Docker Hub at [https://ghcr.io/swri-robotics/bag-database/bag-database:latest](https://ghcr.io/swri-robotics/bag-database/bag-database:latest).
+Pre-built Docker images are on Docker Hub at [https://ghcr.io/swri-robotics/bag-database:latest](https://ghcr.io/swri-robotics/bag-database:latest).
 
 Let us know how it works for you!
 

--- a/docs/installation/docker/without-compose.md
+++ b/docs/installation/docker/without-compose.md
@@ -26,7 +26,7 @@ docker run -d \
     -e METADATA_TOPICS="/metadata" \
     -e VEHICLE_NAME_TOPICS="/vehicle_name" \
     -e GPS_TOPICS="/localization/gps, /gps, /imu/fix" \
-    ghcr.io/swri-robotics/bag-database/bag-database:latest
+    ghcr.io/swri-robotics/bag-database:latest
 ```
 
 After the bag database has successfully started, the bag database should be

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -20,7 +20,7 @@ copy of the database container's volume.
 
 As long as you're using the same version of PostgreSQL, upgrading should be
 painless.  Pull the latest version of the Bag Database image
-(`docker pull ghcr.io/swri-robotics/bag-database/bag-database:latest`) and restarts its container;
+(`docker pull ghcr.io/swri-robotics/bag-database:latest`) and restarts its container;
 if there are any database schema changes, it will automatically update everything.
 
 If you are also updating your PostgreSQL container, you will need to manually


### PR DESCRIPTION
Instead of docker registry paths looking like `swri-robotics/bag-database/bag-database:tag` they now just look like `swri-robotics/bag-database:tag`.